### PR TITLE
Don't read the file when making its hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,8 @@ module.exports = function(options) {
                 tools.revReferencesInFile(file, options.rootDir);
         }
 
-        // Rename this file with the revion hash
-        var filenameReved = path.basename(tools.revFile(file.path));
-        var base = path.dirname(file.path);
-        file.path = path.join(base, filenameReved);
+        // Rename this file with the revision hash
+        tools.revFile(file);
 
         callback(null, file);
 

--- a/tools.js
+++ b/tools.js
@@ -6,36 +6,18 @@ var gutil = require('gulp-util');
 module.exports = function(options) {
 
     var filepathRegex = /.*?(?:\'|\")([a-z0-9_\-\/\.]+?\.[a-z]{2,4})(?:(?:\?|\#)[^'"]*?|)(?:\'|\").*?/ig;
-    var fileMap = {};
     var hashLength = options.hashLength || 8;
 
-    // Taken from gulp-rev: https://github.com/sindresorhus/gulp-rev
-    var md5 = function (str) {
-        return crypto.createHash('md5').update(str, 'utf8').digest('hex');
-    };
+    var revFile = function (file) {
+        var ext = path.extname(file.path);
 
-    // Taken from gulp-rev: https://github.com/sindresorhus/gulp-rev
-    var revFile = function (filePath) {
-        if (fileMap[filePath]) {
-          return fileMap[filePath];
-        }
+        if (options.ignoredExtensions && options.ignoredExtensions.indexOf(ext) !== -1)
+            return;
 
-        var filename,
-            filenameReved,
-            ext = path.extname(filePath);
+        var hash = crypto.createHash('md5').update(file.contents).digest('hex');
+        var filename = path.basename(file.path, ext) + '-' + hash.slice(0, hashLength) + ext;
 
-        if (typeof options.ignoredExtensions === 'undefined' || options.ignoredExtensions.indexOf(ext) === -1) {
-            var contents = fs.readFileSync(filePath).toString();
-            var hash = md5(contents).slice(0, hashLength);
-            filename = path.basename(filePath, ext) + '-' + hash + ext;
-        } else {
-            filename = path.basename(filePath);
-        }
-
-        filePathReved = path.join(path.dirname(filePath), filename);
-
-        fileMap[filePath] = filePathReved;
-        return fileMap[filePath];
+        file.path = path.join(path.dirname(file.path), filename);
     };
 
     var revReferencesInFile = function (file, rootDir) {


### PR DESCRIPTION
When combining rev-all in a pipeline that modifies the name of a file,
the call to fs.readFileSync fails because the original file is not
present on disk.

This commit eschews reading the file's contents in order to calculate
its checksum, prefering instead to use the file's content property.

Also, the revFile function now modifies the file object directly, same
as revReferencesInFile.
