### PR TITLE
Support arbitrary URL transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ gulp.task('default', function () {
 
 });
 ```
-  
+
   * See [gulp-s3](https://www.npmjs.org/package/gulp-s3), [gulp-gzip](https://www.npmjs.org/package/gulp-gzip), [gulp-cloudfront](https://www.npmjs.org/package/gulp-cloudfront)
 
 
@@ -103,7 +103,7 @@ gulp.task('default', function () {
 
 #### options.hashLength
 
-Type: `hashLength`          
+Type: `hashLength`
 Default: `8`
 
 Change the length of the hash appended to the end of each file:
@@ -116,12 +116,38 @@ gulp.task('default', function () {
 });
 ```
 
-#### options.prefix
+#### options.transform
 
-Type: `prefix`          
+Type: `function (rev, source, path)`
 Default: `none`
 
-Prefixes matched files with a string. Useful for adding a full url path to files. 
+Specify a function to transform the reference path. Useful in instances where the local file structure does not reflect what the remote file structure will be.
+
+The function takes three arguments:
+  - `rev` - revisioned reference path
+  - `source` - original reference path
+  - `path` - path to the file
+
+
+```js
+gulp.task('default', function () {
+    gulp.src('dist/**')
+        .pipe(revall({
+            transform: function (rev, source, path) {
+                // on the remote server, image files are served from `/images`
+                return rev.replace('/img', '/images');
+            }
+        }))
+        .pipe(gulp.dest('dist'))
+});
+```
+
+#### options.prefix
+
+Type: `prefix`
+Default: `none`
+
+Prefixes matched files with a string (use `options.transform` for more complicated scenarios). Useful for adding a full url path to files.
 
 ```js
 gulp.task('default', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -179,14 +179,33 @@ describe("gulp-rev-all", function () {
         });
 
         it ("should prefix replaced references if a prefix is supplied", function(done) {
-          stream = revall({rootDir:'test/fixtures/config1', prefix: 'http://example.com'})
-          stream.on('data', function (file) {
-              var revedReference = path.basename(tools.revFile('test/fixtures/config1/index.html'));
-              String(file.contents).should.containEql("http://example.com/" + revedReference);
-              done();
-          });
+            stream = revall({
+                rootDir:'test/fixtures/config1',
+                prefix: 'http://example.com/'
+            })
+            stream.on('data', function (file) {
+                var revedReference = path.basename(tools.revFile('test/fixtures/config1/index.html'));
+                String(file.contents).should.containEql("http://example.com/" + revedReference);
+                done();
+            });
 
-          writeFile();
+            writeFile();
+        });
+
+        it ("should prefix replaced references if a prefix is supplied", function(done) {
+            stream = revall({
+                rootDir:'test/fixtures/config1',
+                transform: function (reved, source, path) {
+                    return this.joinUrlPath('//images.example.com/', reved.replace('img/', ''));
+                }
+            })
+            stream.on('data', function (file) {
+                var revedImage = path.basename(tools.revFile('test/fixtures/config1/img/image1.jpg'));
+                String(file.contents).should.containEql("//images.example.com/" + revedImage.replace('img/', ''));
+                done();
+            });
+
+            writeFile();
         });
 
         it("should resolve reference to css", function(done) {

--- a/tools.js
+++ b/tools.js
@@ -7,7 +7,13 @@ module.exports = function(options) {
 
     var filepathRegex = /.*?(?:\'|\")([a-z0-9_\-\/\.]+?\.[a-z]{2,})(?:(?:\?|\#)[^'"]*?|)(?:\'|\").*?/ig;
     var fileMap = {};
-    
+
+    var joinUrlPath = function (prefix, path) {
+        prefix = prefix.replace(/\/$/, '');
+        path = path.replace(/^\//, '');
+        return [ prefix, path ].join('/');
+    }
+
     // Taken from gulp-rev: https://github.com/sindresorhus/gulp-rev
     var md5 = function (str) {
         return crypto.createHash('md5').update(str, 'utf8').digest('hex');
@@ -41,7 +47,7 @@ module.exports = function(options) {
             var contents = fs.readFileSync(filePath).toString();
             var hash = md5(contents).slice(0, options.hashLength);
             filename = path.basename(filePath, ext) + '.rev.' + hash + ext;
-        } 
+        }
 
         filePathReved = path.join(path.dirname(filePath), filename);
 
@@ -51,37 +57,46 @@ module.exports = function(options) {
 
     var revReferencesInFile = function (file) {
 
+        var self = this;
         var replaceMap = {};
+
+        var getReplacement = function (source, fullpath, relative) {
+            if (fs.existsSync(fullpath)) {
+                var newPath = path.join(path.dirname(source), path.basename(self.revFile(fullpath)));
+                if (options.transform) {
+                    newPath = options.transform.call(self, newPath, source, fullpath);
+                }
+                else if (!relative && options.prefix) {
+                    newPath = self.joinUrlPath(options.prefix, newPath);
+                }
+
+                var msg = relative ? 'relative' : 'root';
+                gutil.log('gulp-rev-all:', 'Found', msg, 'reference [', source, '] -> [', newPath, ']');
+
+                return newPath;
+            }
+
+            return false;
+        };
 
         gutil.log('gulp-rev-all:', 'Finding references in [', file.path, ']');
         // Create a map of file references and their proper revisioned name
         var contents = String(file.contents);
         var result;
         while (result = filepathRegex.exec(contents)) {
+            var source = result[1];
 
             // Skip if we've already resolved this reference
-            if (typeof replaceMap[result[1]] !== 'undefined') continue;
-            replaceMap[result[1]] = false;
+            if (typeof replaceMap[source] !== 'undefined') continue;
+            replaceMap[source] = false;
 
             // In the case where the referenced file is relative to the base path
-            var fullpath = path.join(options.rootDir, result[1]);
-            if (fs.existsSync(fullpath)) {
-                newPath = path.join(path.dirname(result[1]), path.basename(revFile(fullpath)));
-                if (options.prefix) {
-                  newPath = options.prefix + newPath;
-                }
-                replaceMap[result[1]] = newPath;
-                gutil.log('gulp-rev-all:', 'Found root reference [', result[1], '] -> [', replaceMap[result[1]], ']');
-                continue;
-            }
+            var fullpath = path.join(options.rootDir, source);
+            if (replaceMap[source] = getReplacement(source, fullpath)) continue;
 
             // In the case where the file referenced is relative to the file being processed
-            var fullpath = path.join(path.dirname(file.path), result[1]);
-            if (fs.existsSync(fullpath)) {
-                replaceMap[result[1]] = path.join(path.dirname(result[1]), path.basename(revFile(fullpath)));
-                gutil.log('gulp-rev-all:', 'Found relative reference [', result[1], '] -> [', replaceMap[result[1]], ']');
-                continue;
-            }
+            fullpath = path.join(path.dirname(file.path), source);
+            replaceMap[source] = getReplacement(source, fullpath, true);
 
         }
 
@@ -96,6 +111,7 @@ module.exports = function(options) {
 
 
     return {
+        joinUrlPath: joinUrlPath,
         revFile: revFile,
         revReferencesInFile: revReferencesInFile,
         isFileIgnored: isFileIgnored


### PR DESCRIPTION
Similar to #13, but for arbitrary transformations.

**Use case:**
We were running into issues because all of our front-end projects (in seperate repos) share rev'd JS dependencies at the root of our CDN. On deployment, paths like `/lib/**/*.js` needed to be translated to `//cdn.example.com/*.<rev>.js`. The example below satisfied our requirements.

**Usage:**

``` js
gulp.task('default', function () {
  gulp.src('dist/**')
      .pipe(revall({
        transform: function (rev, source, path) {
          return '//cdn.example.com/' + path.basename(rev);
         }
      }))
      .pipe(gulp.dest('dist'))
});
```

**Notes:**
`this` refers to `tools` within the transform function, so any helper methods can be called if necessary. This isn't particularly useful for anything other than `this.joinUrlPath()` right now.
