### PR TITLE
Supporting custom file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function(options) {
 
     var first = true;    
     options = options || {};
-    options.hashLength = options.hashLength || 8;
+    options.hashLength  = options.hashLength || 8;
+    options.fileExt     = options.fileExt || ['.js', '.css', '.html', '.jade'];
     options.ignore = options.ignore || options.ignoredExtensions || [ /^\/favicon.ico$/g ];
 
     return through.obj(function (file, enc, callback) {
@@ -29,12 +30,10 @@ module.exports = function(options) {
             throw new Error('Streams are not supported!');
         } 
 
-        // Only process references in these types of files, otherwise we'll corrupt images etc
-        switch(path.extname(file.path)) {
-            case '.js':
-            case '.css':
-            case '.html':
-                tools.revReferencesInFile(file);
+        var ext = path.extname(file.path);
+
+        if (options.fileExt.indexOf(ext) !== -1) {
+            tools.revReferencesInFile(file);
         }
 
         // Rename this file with the revion hash if doesn't match ignore list

--- a/test/fixtures/config1/index.jade
+++ b/test/fixtures/config1/index.jade
@@ -1,0 +1,4 @@
+html
+    head
+        link(rel="stylesheet", href="css/style.css")
+    body

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,34 @@ describe("gulp-rev-all", function () {
             });
         });
 
+        describe("fileExt", function() {
+            it("should not rename files with certain extensions when specified", function (done) {
+                stream = revall({rootDir: 'test/fixtures/config1', fileExt: ['.html']});
+                stream.on('data', function (file) {
+                    if (file.path.match(/jade/)) {
+                        String(file.contents).should.match(/css\/style\.css/);
+                    }
+                });
+
+                stream.on('end', done);
+
+                writeFile();
+            });
+
+            it("should rename files with default extensions, like .html or .jade", function (done) {
+                stream = revall({rootDir: 'test/fixtures/config1'});
+                stream.on('data', function (file) {
+                    if (file.path.match(/jade/)) {
+                        String(file.contents).should.match(/css\/style\.(.*)\.css/);
+                    }
+                });
+
+                stream.on('end', done);
+
+                writeFile();
+            });
+        });
+
     });
 
     describe("root html", function() {


### PR DESCRIPTION
Hola!
- enabled js, css, html and jade by default
- you can specify which file extensions to rev with `options.fileExt`
- added tests to verify that you can exclude/include file extensions at will

Long story short, we use express and use the view cache, so that
jade templates are compiled upon the first request.
At the same time we also need to rev some file on those jade files,
but gulp-rev-all doesnt rev references in them as it only supports
html|css|js, and it's a bit too strict :)
