### PR TITLE
adding options.silent, options.quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ gulp.task('default', function () {
 });
 ```
 
+#### options.silent
+#### options.quiet
+
+Type: `Boolean`
+Default: `false`
+
+If you set this options to true gulp will no longer emit `gulp-rev-all` log messages.
+
 ## Tips
 
 Make sure to set the files to [never expire](http://developer.yahoo.com/performance/rules.html#expires) for this to have an effect.

--- a/tool.js
+++ b/tool.js
@@ -12,6 +12,9 @@ module.exports = function(options) {
     var fs = options.fs || gracefulfs;
     var path = options.path || patho;
 
+    // Disable logging
+    if (options.silent == true || options.quiet == true) gutil.log = function() {}
+
     var joinPathUrl = function (prefix, path) {
         prefix = prefix.replace(/\/$/, '');
         path = path.replace(/^\//, '');


### PR DESCRIPTION
I'm sure others will appreciate this small feature. By passing `quiet=true` or `silent=true`, logs will not be printed.
