### PR TITLE
adding revall.manifest({ fileName: '' }) option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ gulp.task('default', function () {
         .pipe(gulp.dest('build/assets'))  // copy original assets to build dir
         .pipe(revall())
         .pipe(gulp.dest('build/assets'))  // write rev'd assets to build dir
-        .pipe(revall.manifest())
+        .pipe(revall.manifest({ fileName: 'manifest.json' })) // create manifest (`fileName` is optional)
         .pipe(gulp.dest('build/assets')); // write manifest to build dir
 });
 ```

--- a/index.js
+++ b/index.js
@@ -31,11 +31,12 @@ var plugin = function (options) {
 
 
 // Borrowed from: https://github.com/sindresorhus/gulp-rev
-plugin.manifest = function () {
+plugin.manifest = function (options) {
 
     var manifest  = {};
     var firstFile = null;
     var tool = toolFactory();
+    var fileName = options.fileName || 'rev-manifest.json';
 
     return through.obj(function (file, enc, cb) {
 
@@ -52,7 +53,7 @@ plugin.manifest = function () {
             this.push(new gutil.File({
                 cwd: firstFile.cwd,
                 base: firstFile.base,
-                path: path.join(firstFile.base, 'rev-manifest.json'),
+                path: path.join(firstFile.base, fileName),
                 contents: new Buffer(JSON.stringify(manifest, null, '  '))
             }));
         }


### PR DESCRIPTION
It's good to have an options to rename the manifest's file name thus you can have multiple manifests in the same directory.
