### PR TITLE
Do not use for..in to iterate over refs array.

### DIFF
--- a/tool.js
+++ b/tool.js
@@ -228,7 +228,7 @@ module.exports = function(options) {
         var fileBasePath = path.resolve(file.base);
         var fileDir = path.dirname(file.path);
 
-        for (var key in refs) {
+        for (var key = 0; key < refs.length; key++) {
 
             var reference = refs[key].reference;
             var isAmdCommonJs = refs[key].isAmdCommonJs;


### PR DESCRIPTION
It's the recommended way to iterate over an array to avoid iterating over other properties of the array object.

Seems TypeScript linter was adding props on the Array prototype, breaking my gulp file whenever it was ran before gulp-rev-all...
