### PR TITLE
sourceMapRegex was picking up trailing spaces

### DIFF
--- a/tool.js
+++ b/tool.js
@@ -129,7 +129,7 @@ module.exports = function(options) {
 
         while ((result = sourcemapRegex.exec(regularContent))) {
           refs.push({
-            reference: result[1],
+            reference: result[1].trim(),
             isAmdCommonJs: false
           })
         }


### PR DESCRIPTION
trim() seemed like a simple solution rather than complicating the regex.