### PR TITLE
For relative paths, prefer dir-relative refs

### DIFF
--- a/tool.js
+++ b/tool.js
@@ -272,12 +272,6 @@ module.exports = function(options) {
                     });
                 }
 
-                referencePaths.push({
-                    base: fileBasePath,
-                    path: joinPath(fileBasePath, reference_),
-                    isRelative: false
-                });
-
                 if (pathType === 'relative') {
                     referencePaths.push({
                         base: fileBasePath,
@@ -285,6 +279,12 @@ module.exports = function(options) {
                         isRelative: true
                     });
                 }
+
+                referencePaths.push({
+                    base: fileBasePath,
+                    path: joinPath(fileBasePath, reference_),
+                    isRelative: false
+                });
 
             }
 


### PR DESCRIPTION
We have a structure, simplified, something like:

```
┬ webapp
│
├──┐ subdir
│  ├─ index.html (references "./templates.js")
│  └─ templates.js (→"templates.e017c148.subdir.js")
│
├─ index.html (references "templates.js")
└─ templates.js (→"templates.2a52265e.root.js")
```

When I run `grunt-rev-all` agains this, in spite of the explicit relative path in `subdir/index.html`, it will contain the wrong reference -- both will refer to `templates.2a52265e.root.js`.

The problem seems to come from `tool.js` around line 277:

```javascript
                referencePaths.push({
                    base: fileBasePath,
                    path: joinPath(fileBasePath, reference_),
                    isRelative: false
                });

                if (pathType === 'relative') {
                    referencePaths.push({
                        base: fileBasePath,
                        path: joinPath(fileDir, reference_),
                        isRelative: true
                    });
                }
```

I'm sure there's a good reason for considering root paths even when the references are relative, _but_ the problem here is that they aren't just considered, but _preferred_ because they're pushed first. My fairly dumb PR simply reverses this, s.t. the relative path is checked before falling back to root, rather than the current _vice versa_. However, I have no idea whether this might cause other problems. It looks like it Works For Me™...