### PR TITLE
add option to explicitly ignore finding references in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,21 @@ gulp.task('default', function () {
 });
 ```
 
+#### options.ignoreRefs
+
+Type: `Array of (Regex and/or String)`
+Default: `[ /^\.svg$/ ]`
+
+In some cases, you may not want to replace references in your `*.csv` files:
+
+```js
+gulp.task('default', function () {
+    gulp.src('dist/**')
+        .pipe(revall({ ignoreRefs: [/^\.svg$/g, '.csv'] }))
+        .pipe(gulp.dest('cdn'))
+});
+```
+
 #### options.hashLength
 
 Type: `hashLength`

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var plugin = function (options) {
     options = options || {};
     options.hashLength  = options.hashLength || 8;
     options.ignore = options.ignore || options.ignoredExtensions || [ /^\/favicon.ico$/g ];
+    options.ignoreRefs = options.ignoreRefs || options.ignoredReferences || [ /\.svg$/g ];
 
     var tool = new toolFactory(options);
 
@@ -20,7 +21,7 @@ var plugin = function (options) {
             return callback(null, file);
         } else if (file.isStream()) {
             throw new Error('Streams are not supported!');
-        } 
+        }
 
         tool.revisionFile(file);
         callback(null, file);
@@ -31,7 +32,7 @@ var plugin = function (options) {
         }
 
         cb();
-    });    
+    });
 
 };
 
@@ -52,7 +53,7 @@ plugin.versionFile = function(options) {
         cb();
 
     }, function (cb) {
-        
+
         var out = {
             hash: hash,
             timestamp: new Date()
@@ -92,7 +93,7 @@ plugin.manifest = function (options) {
         cb();
 
     }, function (cb) {
-        
+
         if (firstFile) {
             this.push(new gutil.File({
                 cwd: firstFile.cwd,

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ describe("gulp-rev-all", function () {
 
         it('should change if child reference changes', function (done) {
 
-            tool = new toolFactory({hashLength: 8, ignore: ['favicon.ico']});
+            tool = new toolFactory({hashLength: 8, ignore: ['favicon.ico'], ignoreRefs: ['.svg']});
             var fileStyleBaseline = tool.revisionFile(getFile('test/fixtures/config1/css/style.css'));
 
             var fsMock = {
@@ -594,7 +594,7 @@ describe("gulp-rev-all", function () {
     describe("main js", function () {
 
         beforeEach(function (done) {
-            tool = new toolFactory({ hashLength: 8, ignore: ['favicon.ico']});
+            tool = new toolFactory({ hashLength: 8, ignore: ['favicon.ico'], ignoreRefs: ['.svg']});
             stream = revall();
             done();
         });

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ var path = require('path');
 var gutil = require("gulp-util");
 var glob = require("glob");
 var sinon = require("sinon");
- 
+
 require("mocha");
 
 describe("gulp-rev-all", function () {
@@ -155,7 +155,7 @@ describe("gulp-rev-all", function () {
             };
 
             run1();
-            
+
         });
 
     });
@@ -373,7 +373,7 @@ describe("gulp-rev-all", function () {
             });
 
             stream.on('data', function () {});
-            stream.on('end', function () { 
+            stream.on('end', function () {
                 var file = tool.cache[tool.cachePath(filename)].file;
                 var revedReference = path.basename(tool.revisionFile(getFile('test/fixtures/config1/css/style.css')).path);
                 String(file.contents).should.containEql(revedReference);
@@ -487,7 +487,7 @@ describe("gulp-rev-all", function () {
             stream = revall({getTool: function (t){tool = t;}});
             done();
         });
-        
+
         var filename = path.join(base, 'view/main.html');
         var file;
         var writeFile = function () {
@@ -658,7 +658,7 @@ describe("gulp-rev-all", function () {
 
         });
 
-    
+
         it("should resolve references to angularjs views", function (done) {
 
             stream.on('data', function () {});


### PR DESCRIPTION
Currently only non-binary files are ignored from being searched for references to be replaced with transformed file paths. This PR adds the option `ignoreRefs`, which is very similar to the `ignore` option, to explicitly ignore finding references in files. An example use case for this, and the default `ignoreRef` option, is ignoring searching for references in `.svg` files.