### PR TITLE
fix absolute paths on windows

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -281,7 +281,7 @@ var Revisioner = (function () {
 
             // Replace regular filename with revisioned version
             var pathReferenceReplace;
-            if (reference.file.revFilenameExtOriginal == '.js' && !reference.path.match(/.js$/)) {
+            if (reference.file.revFilenameExtOriginal == '.js' && !reference.path.match(/\.js$/)) {
                 pathReferenceReplace = reference.path.substr(0, reference.path.length - reference.file.revFilenameOriginal.length);
                 pathReferenceReplace += reference.file.revFilename.substr(0, reference.file.revFilename.length - 3);              
             } else {

--- a/tool.js
+++ b/tool.js
@@ -31,8 +31,8 @@ module.exports = (function() {
         if (base === path) return '';
 
         // Sanitize inputs, convert windows to posix style slashes, remove trailing slash off base is there is one
-        base = base.replace(/\\/g, '/').replace(/\/$/g, '');
-        path = path.substr(base.length).replace(/\\/g, '/');
+        base = base.replace(/^[a-z]:\\/i, '/').replace(/\\/g, '/').replace(/\/$/g, '');
+        path = path.replace(/^[a-z]:\\/i, '/').replace(/\\/g, '/').substr(base.length);
 
         if (path.indexOf('/') == 0 && noStartingSlash) {
             path = path.substr(1);
@@ -102,17 +102,18 @@ module.exports = (function() {
             var pathFile = Path.dirname(get_relative_path(file.base, file.revPathOriginal)); 
 
             // ../second/index.html
-            representations.push(Path.relative(pathFile, pathCurrentReference) + '/' + Path.basename(fileCurrentReference.revPathOriginal));
-
+            var relPath = Path.relative(pathFile, pathCurrentReference);
+            relPath = relPath.replace(/\\/g, '/');
+            representations.push(relPath + '/' + Path.basename(fileCurrentReference.revPathOriginal));
         }
 
         // Only care about trying to match shorthand javascript includes in javascript file context
-        if (file.revPathOriginal.match(/.js$/ig)) {
+        if (file.revPathOriginal.match(/\.js$/ig)) {
             // Create alternative representations for javascript files for frameworks that omit the .js extension
             for (var i = 0, length = representations.length; i < length; i++) {
 
                 // Skip non-javascript files, also ensure the folder has at least one directory in it (so we don't end up with super short single words)
-                if (!representations[i].match(/.js$/ig) || !representations[i].match(/\//ig)) continue;
+                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)) continue;
 
                 representations.push(representations[i].substr(0, representations[i].length - 3));
             }
@@ -143,12 +144,12 @@ module.exports = (function() {
         }
 
         // Only care about trying to match shorthand javascript includes in javascript file context
-        if (file.revPathOriginal.match(/.js$/ig)) {
+        if (file.revPathOriginal.match(/\.js$/ig)) {
             // Create alternative representations for javascript files for frameworks that omit the .js extension
             for (var i = 0, length = representations.length; i < length; i++) {
 
                 // Skip non-javascript files, also ensure the folder has at least one directory in it (so we don't end up with super short single words)
-                if (!representations[i].match(/.js$/ig) || !representations[i].match(/\//ig)) continue;
+                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)) continue;
 
                 representations.push(representations[i].substr(0, representations[i].length - 3));
             }

--- a/tool.js
+++ b/tool.js
@@ -17,7 +17,7 @@ module.exports = (function() {
      */
     var join_path = function (directory, filename) {
         
-        var path = Path.join(directory, filename).replace(/\\/g, '/');
+        var path = Path.join(directory, filename).replace(/^[a-z]:\\/i, '/').replace(/\\/g, '/');
         return (path.indexOf('/') == 0) ? path : '/' + path;
 
     };


### PR DESCRIPTION
Absolute paths did not resolve correctly on windows.

The revisioner.js calls in line 254:
`file.path = this.Tool.join_path(Path.dirname(file.path), filename);`

The `Path.dirname(file.path)` resolves on windows to paths that contains the drive:
`d:\path\to\project\index.html` 
Later in the script the path will be relativized, which resolve to relative paths again. The resulting path is broken on windows it looks like these:
`../../../d:/path/to/project/index.html`. 

The attached fix solves the issue for me, it just remove the drive from the path.