### PR TITLE
Fix file resolution issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ options.annotater = function(contents, path){
 
 The replacer function's job is to replace references to revisioned files. The paremeters are as folows:<br/>
 
-```fragment```: is a file fragment as created in the annotator function.<br/>
+```fragment```: a file fragment as created in the annotator function.<br/>
 ```replaceRegExp```: parameter is a regular expression that can be used to match the part of the fragement to be replaced. The regular expression has 4 capture groups. $1 & $4 are what precedes and follows the reference. $2 is the file path without the extension, and $3 is the file extension.<br/>
-```newReference```: is what gulp-rev-all wants to replace the file path without the extension ($2) with.<br/>
+```newReference```: what gulp-rev-all wants to replace the file path without the extension ($2) with.<br/>
 ```referencedFile```: contains additional properties of the file reference thats being replaced. See the 'Additional Properties' section for more information.<br/>
 
 The default replacer function is as follows:

--- a/README.md
+++ b/README.md
@@ -304,6 +304,66 @@ If you set this options to true, verbose logging will be emitted to console.<br/
 Type: `Boolean`<br/>
 Default: `false`<br/>
 
+## Annotater & Replacer
+
+In some cases content that is not a file reference may be incorrectly be replaced with a file reference.<br/>
+
+In the example below the 2nd instance of 'xyz' is not reference to the file xyz.js:
+
+```js
+require('xyz');
+
+angular.controller('myController', ['xyz', function(xyz){
+   ...
+}]);
+```
+
+It will hoever still be replaced resulting in file corruption:
+
+```js
+require('xyz.123');
+
+angular.controller('myController', ['xyz.123', function(xyz){
+   ...
+}]);
+
+This behaviour can be avoided by passing custom ```annotator``` and ```replacer``` functions in as options.
+
+### Annotator
+
+The annotator function is called with the original file content and path.
+Annotator function should return a list of objects that contain fragments of the file content in order.
+You may split the file up into as many fragments as necessary and attach any other metadata to the fragments.
+The file will be reassembled in order. <br/>
+
+The default annotator returns one fragment with no annotations:
+
+```js
+options.annotater = function(contents, path){
+    var fragments = [{'contents': contents}];
+    return fragments;
+};
+```
+
+### Replacer
+
+The replacer function's job is to replace references to revisioned files. The paremeters are as folows:<br/>
+
+```fragment```: is a file fragment as created in the annotator function.<br/>
+```replaceRegExp```: parameter is a regular expression that can be used to match the part of the fragement to be replaced. The regular expression has 4 capture groups. $1 & $4 are what precedes and follows the reference. $2 is the file path without the extension, and $3 is the file extension.<br/>
+```newReference```: is what gulp-rev-all wants to replace the file path without the extension ($2) with.<br/>
+```referencedFile```: contains additional properties of the file reference thats being replaced. See the 'Additional Properties' section for more information.<br/>
+
+The default replacer function is as follows:
+
+```js
+options.replacer = function(fragment, replaceRegExp, newReference, referencedFile){
+     fragment.contents = fragment.contents.replace(replaceRegExp, '$1' + newReference + '$3$4');
+};
+```
+
+You can overide the default annotator and replacer to change the behaviour of gulp-rev-all and deal with problematic edge cases.
+
 ## Additional Properties
 
 ### file.revPathOriginal 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ The file will be reassembled in order. <br/>
 The default annotator returns one fragment with no annotations:
 
 ```js
-options.annotater = function(contents, path){
+options.annotator = function(contents, path){
     var fragments = [{'contents': contents}];
     return fragments;
 };

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ require('xyz.123');
 angular.controller('myController', ['xyz.123', function(xyz){
    ...
 }]);
+```
 
 This behaviour can be avoided by passing custom ```annotator``` and ```replacer``` functions in as options.
 

--- a/revisioner.js
+++ b/revisioner.js
@@ -4,7 +4,7 @@ var Path = require('path');
 var Tool = require('./tool');
 
 var Revisioner = (function () {
-
+    'use strict';
     var Revisioner = function(options) {
 
         this.options = Merge({
@@ -165,7 +165,9 @@ var Revisioner = (function () {
         fileResolveReferencesIn.revReferenceFiles = {};
 
         // Don't try and resolve references in binary files or files that have been blacklisted
-        if (this.Tool.is_binary_file(fileResolveReferencesIn) || !this.shouldSearchFile(fileResolveReferencesIn)) return;
+        if (this.Tool.is_binary_file(fileResolveReferencesIn) || !this.shouldSearchFile(fileResolveReferencesIn)) {
+            return;
+        }
 
         var referenceGroupRelative = [];
         var referenceGroupAbsolute = [];
@@ -217,7 +219,7 @@ var Revisioner = (function () {
                 if(isJSReference){
                     // expect js file references to be qouted
                     ['\'', '"'].map(function(prefixSuffix){
-                        // Javascript files may be refered to without an extention
+                        // Javascript files may be refered to without an extension
                         var regExp = '('+ prefixSuffix +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ prefixSuffix + '|$)';
                         regExps.push(new RegExp(regExp, 'g'));
                     });
@@ -228,7 +230,7 @@ var Revisioner = (function () {
                     regExps.push(new RegExp(regExp, 'g'));
                 }
 
-                self = this;
+                var self = this;
                 
                 regExps.map(function(regExp){
                     if (contents.match(regExp)) {
@@ -296,7 +298,6 @@ var Revisioner = (function () {
      */
     Revisioner.prototype.revisionFilename = function (file) {
 
-        var hash = file.revHashOriginal;
         var filename = file.revFilenameOriginal;
         var ext = file.revFilenameExtOriginal;
 
@@ -334,7 +335,9 @@ var Revisioner = (function () {
     Revisioner.prototype.updateReferences = function (file) {
 
         // Don't try and update references in binary files
-        if (this.Tool.is_binary_file(file)) return;
+        if (this.Tool.is_binary_file(file)){
+            return;
+        }
 
         var contents = String(file.revContentsOriginal);
         for (var pathReference in file.revReferencePaths) {
@@ -343,7 +346,7 @@ var Revisioner = (function () {
 
             // Replace regular filename with revisioned version
             var pathReferenceReplace;
-            if (reference.file.revFilenameExtOriginal == '.js' && !reference.path.match(/\.js$/)) {
+            if (reference.file.revFilenameExtOriginal === '.js' && !reference.path.match(/\.js$/)) {
                 pathReferenceReplace = reference.path.substr(0, reference.path.length - reference.file.revFilenameOriginal.length);
                 pathReferenceReplace += reference.file.revFilename.substr(0, reference.file.revFilename.length - 3);
             } else {
@@ -353,7 +356,7 @@ var Revisioner = (function () {
 
             // Transform path using client supplied transformPath callback, if none try and append with user supplied prefix (defaults to '')
             pathReferenceReplace = (this.options.transformPath) ? this.options.transformPath.call(this, pathReferenceReplace, reference.path, reference.file) :
-                                   (this.options.prefix && pathReferenceReplace[0] == '/') ? this.Tool.join_path_url(this.options.prefix, pathReferenceReplace) : pathReferenceReplace;
+                                   (this.options.prefix && pathReferenceReplace[0] === '/') ? this.Tool.join_path_url(this.options.prefix, pathReferenceReplace) : pathReferenceReplace;
 
             if (this.shouldUpdateReference(reference.file)) {
                 // The extention should remain constant so we dont add extentions to references without extentions

--- a/revisioner.js
+++ b/revisioner.js
@@ -365,7 +365,7 @@ var Revisioner = (function () {
             if (this.shouldUpdateReference(reference.file)) {
                 // The extention should remain constant so we dont add extentions to references without extentions
                 var noExtReplace = Tool.path_without_ext(pathReferenceReplace);
-                contents = contents.replace(reference.regExp, '$1' + noExtReplace + '$3' + '$4');
+                contents = contents.replace(reference.regExp, '$1' + noExtReplace + '$3$4');
             }
 
         }

--- a/revisioner.js
+++ b/revisioner.js
@@ -214,6 +214,7 @@ var Revisioner = (function () {
         }
 
         var nonFileNameChar = '[^a-z0-9\\.\\-\\_\/]';
+        var qoutes = '\'|"';
 
         // Priority relative references higher than absolute
         for (var referenceType in referenceGroupsContainer) {
@@ -230,12 +231,9 @@ var Revisioner = (function () {
 
                 if(isJSReference){
                     // expect js file references to be qouted
-                    ['\'', '"'].map(function(prefixSuffix){
-                        // Javascript files may be refered to without an extension
-                        var regExp = '('+ prefixSuffix +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ prefixSuffix + '|$)';
-                        regExps.push(new RegExp(regExp, 'g'));
-                    });
-                    
+                    // Javascript files may be refered to without an extension
+                    var regExp = '('+ qoutes +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ qoutes + '|$)';
+                    regExps.push(new RegExp(regExp, 'g'));
                 } else {
                     // Expect left and right sides of the reference to be a non-filename type character, escape special regex chars
                     var regExp = '('+ nonFileNameChar +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')('+ nonFileNameChar + '|$)';

--- a/revisioner.js
+++ b/revisioner.js
@@ -232,7 +232,7 @@ var Revisioner = (function () {
                     // Expect left and right sides of the reference to be a non-filename type character, escape special regex chars
                     var regExp = '('+ nonFileNameChar +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')('+ nonFileNameChar + '|$)';
                     regExps.push(new RegExp(regExp, 'g'));
-                    
+
                 }
 
                 var self = this;
@@ -316,7 +316,6 @@ var Revisioner = (function () {
         }
 
         file.revFilename = filename;
-        file.revFilenameNoExt = Tool.path_without_ext(file.revFilename);
 
         if (this.shouldFileBeRenamed(file)) {
             file.path = this.Tool.join_path(Path.dirname(file.path), filename);

--- a/revisioner.js
+++ b/revisioner.js
@@ -253,7 +253,7 @@ var Revisioner = (function () {
 
             for (var key in file.revReferenceFiles) {
 
-                // Prevent infinite loops caused by circular references be preventing recursion if we've already encountered this file
+                // Prevent infinite loops caused by circular references, don't recurse if we've already encountered this file
                 if (stack.indexOf(file.revReferenceFiles[key]) === -1) {
                     hash += this.calculateHash(file.revReferenceFiles[key], stack);
                 }

--- a/revisioner.js
+++ b/revisioner.js
@@ -41,7 +41,7 @@ var Revisioner = (function () {
         this.Tool = Tool;
 
 
-        var nonFileNameChar = '[^a-z0-9\\.\\-\\_\/]';
+        var nonFileNameChar = '[^a-zA-Z0-9\\.\\-\\_\/]';
         var qoutes = '\'|"';
 
         function referenceToRegexs(reference){

--- a/revisioner.js
+++ b/revisioner.js
@@ -70,7 +70,9 @@ var Revisioner = (function () {
      */
     Revisioner.prototype.processFile = function (file) {
 
-        if (!this.pathCwd) this.pathCwd = file.cwd;
+        if (!this.pathCwd){
+            this.pathCwd = file.cwd;
+        }
 
         // Chnage relative paths to absolute
         if (!file.base.match(/^(\/|[a-z]:)/i)) {
@@ -82,7 +84,7 @@ var Revisioner = (function () {
 
             this.pathBase = file.base;
 
-        } else if (file.base.indexOf(this.pathBase) == -1) {
+        } else if (file.base.indexOf(this.pathBase) === -1) {
 
             var levelsBase = this.pathBase.split(/[\/|\\]/);
             var levelsFile = file.base.split(/[\/|\\]/);
@@ -90,14 +92,16 @@ var Revisioner = (function () {
             var common = [];
             for (var level = 0, length = levelsFile.length; level < length; level++) {
 
-                if (level < levelsBase.length && level < levelsFile.length
-                    && levelsBase[level] == levelsFile[level]) {
+                if (level < levelsBase.length && level < levelsFile.length &&
+                        levelsBase[level] === levelsFile[level]) {
                     common.push(levelsFile[level]);
                     continue;
                 }
             }
 
-            if (common[common.length - 1] != '') common.push('');
+            if (common[common.length - 1] !== ''){
+                common.push('');
+            }
             this.pathBase = common.join('/');
 
         }
@@ -219,7 +223,7 @@ var Revisioner = (function () {
                         };
                         this.log('gulp-rev-all:', 'Found', referenceType, 'reference [', Gutil.colors.magenta(reference.path), '] -> [', Gutil.colors.green(reference.file.path), '] in [', Gutil.colors.blue(fileResolveReferencesIn.revPathOriginal) ,']');
 
-                    } else if (fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal != reference.file.revPathOriginal) {
+                    } else if (fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal !== reference.file.revPathOriginal) {
 
                         this.log('gulp-rev-all:', 'Possible ambiguous refrence detected [', Gutil.colors.red(fileResolveReferencesIn.revReferencePaths[reference.path].path), ' (', fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal, ')] <-> [', Gutil.colors.red(reference.path) ,'(', Gutil.colors.red(reference.file.revPathOriginal), ')]');
 
@@ -249,8 +253,8 @@ var Revisioner = (function () {
 
             for (var key in file.revReferenceFiles) {
 
-                // Prevent infinite loops caused by circular references, don't recurse if we've already encountered this file
-                if (stack.indexOf(file.revReferenceFiles[key]) == -1) {
+                // Prevent infinite loops caused by circular references be preventing recursion if we've already encountered this file
+                if (stack.indexOf(file.revReferenceFiles[key]) === -1) {
                     hash += this.calculateHash(file.revReferenceFiles[key], stack);
                 }
 
@@ -258,12 +262,12 @@ var Revisioner = (function () {
 
             // Consolidate many hashes into one
             hash = this.Tool.md5(hash);
-
+            
         }
 
         return hash;
 
-    }
+    };
 
 
     /**

--- a/revisioner.js
+++ b/revisioner.js
@@ -217,17 +217,22 @@ var Revisioner = (function () {
                 var isJSReference = reference.path.match(/\.js$/);
 
                 if(isJSReference){
+
                     // expect js file references to be qouted
                     ['\'', '"'].map(function(prefixSuffix){
+
                         // Javascript files may be refered to without an extension
                         var regExp = '('+ prefixSuffix +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ prefixSuffix + '|$)';
                         regExps.push(new RegExp(regExp, 'g'));
+
                     });
                     
                 } else {
+
                     // Expect left and right sides of the reference to be a non-filename type character, escape special regex chars
                     var regExp = '('+ nonFileNameChar +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')('+ nonFileNameChar + '|$)';
                     regExps.push(new RegExp(regExp, 'g'));
+                    
                 }
 
                 var self = this;

--- a/revisioner.js
+++ b/revisioner.js
@@ -16,12 +16,12 @@ var Revisioner = (function () {
             'fileNameVersion': 'rev-version.json',
             'fileNameManifest': 'rev-manifest.json',
             'prefix': '',
-            'annotater': null,
+            'annotator': null,
             'replacer': null,
             'debug': false
         };
 
-        defaults.annotater = function(contents, path){
+        defaults.annotator = function(contents, path){
             return [{'contents': contents}];
         };
 
@@ -352,7 +352,7 @@ var Revisioner = (function () {
         }
 
         var contents = String(file.revContentsOriginal);
-        var annotatedContent = this.options.annotater(contents, file.revPathOriginal);
+        var annotatedContent = this.options.annotator(contents, file.revPathOriginal);
 
         for (var pathReference in file.revReferencePaths) {
 

--- a/revisioner.js
+++ b/revisioner.js
@@ -262,7 +262,7 @@ var Revisioner = (function () {
 
             // Consolidate many hashes into one
             hash = this.Tool.md5(hash);
-            
+
         }
 
         return hash;

--- a/revisioner.js
+++ b/revisioner.js
@@ -200,7 +200,6 @@ var Revisioner = (function () {
         }
 
         var nonFileNameChar = '[^a-z0-9\\.\\-\\_\/]';
-        var nonFileNameCharWs = '[^a-z0-9\\.\\-\\_\/ \t\r\n\f]';
 
         // Priority relative references higher than absolute
         for (var referenceType in referenceGroupsContainer) {

--- a/revisioner.js
+++ b/revisioner.js
@@ -226,43 +226,41 @@ var Revisioner = (function () {
                 var escapedRefPathBase = Tool.path_without_ext(reference.path).replace(/([^0-9a-z])/ig, '\\$1');
                 var escapedRefPathExt = Path.extname(reference.path).replace(/([^0-9a-z])/ig, '\\$1');
 
-                var regExps = [];
+                var regExp;
                 var isJSReference = reference.path.match(/\.js$/);
 
                 if(isJSReference){
-                    // expect js file references to be qouted
+                    // Javascript file references has to to be qouted
                     // Javascript files may be refered to without an extension
-                    var regExp = '('+ qoutes +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ qoutes + '|$)';
-                    regExps.push(new RegExp(regExp, 'g'));
+                    regExp = '('+ qoutes +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')?('+ qoutes + '|$)';
+
                 } else {
                     // Expect left and right sides of the reference to be a non-filename type character, escape special regex chars
-                    var regExp = '('+ nonFileNameChar +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')('+ nonFileNameChar + '|$)';
-                    regExps.push(new RegExp(regExp, 'g'));
+                    regExp = '('+ nonFileNameChar +')(' + escapedRefPathBase + ')(' +  escapedRefPathExt + ')('+ nonFileNameChar + '|$)';
                 }
 
-                var self = this;
-                
-                regExps.map(function(regExp){
-                    if (contents.match(regExp)) {
-                        // Only register this reference if we don't have one already by the same path
-                        if (!fileResolveReferencesIn.revReferencePaths[reference.path]) {
+                regExp = new RegExp(regExp, 'g');
 
-                            fileResolveReferencesIn.revReferenceFiles[reference.file.path] = reference.file;
-                            fileResolveReferencesIn.revReferencePaths[reference.path] = {
-                                'regExp': regExp,
-                                'file': reference.file,
-                                'path': reference.path
-                            };
-                            self.log('gulp-rev-all:', 'Found', referenceType, 'reference [', Gutil.colors.magenta(reference.path), '] -> [', Gutil.colors.green(reference.file.path), '] in [', Gutil.colors.blue(fileResolveReferencesIn.revPathOriginal) ,']');
+                if (contents.match(regExp)) {
+                    // Only register this reference if we don't have one already by the same path
+                    if (!fileResolveReferencesIn.revReferencePaths[reference.path]) {
 
-                        } else if (fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal !== reference.file.revPathOriginal) {
+                        fileResolveReferencesIn.revReferenceFiles[reference.file.path] = reference.file;
+                        fileResolveReferencesIn.revReferencePaths[reference.path] = {
+                            'regExp': regExp,
+                            'file': reference.file,
+                            'path': reference.path
+                        };
+                        this.log('gulp-rev-all:', 'Found', referenceType, 'reference [', Gutil.colors.magenta(reference.path), '] -> [', Gutil.colors.green(reference.file.path), '] in [', Gutil.colors.blue(fileResolveReferencesIn.revPathOriginal) ,']');
 
-                            self.log('gulp-rev-all:', 'Possible ambiguous refrence detected [', Gutil.colors.red(fileResolveReferencesIn.revReferencePaths[reference.path].path), ' (', fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal, ')] <-> [', Gutil.colors.red(reference.path) ,'(', Gutil.colors.red(reference.file.revPathOriginal), ')]');
+                    } else if (fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal !== reference.file.revPathOriginal) {
 
-                        }
+                        this.log('gulp-rev-all:', 'Possible ambiguous refrence detected [', Gutil.colors.red(fileResolveReferencesIn.revReferencePaths[reference.path].path), ' (', fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal, ')] <-> [', Gutil.colors.red(reference.path) ,'(', Gutil.colors.red(reference.file.revPathOriginal), ')]');
 
                     }
-                });
+
+                }
+
 
             }
         }

--- a/test.js
+++ b/test.js
@@ -1389,11 +1389,9 @@ describe('gulp-rev-all', function () {
 
                         var references = Tool.get_reference_representations_absolute(fileReference, file);
 
-                        references.length.should.equal(4);
+                        references.length.should.equal(2);
                         references[0].should.equal('/third/script.js');
                         references[1].should.equal('third/script.js');
-                        references[2].should.equal('/third/script');
-                        references[3].should.equal('third/script');
 
                     });
 

--- a/test.js
+++ b/test.js
@@ -823,7 +823,24 @@ describe('gulp-rev-all', function () {
 
         });
 
-        it('should not resolve arbitrarty text with the same name as a file', function (done) {
+        it('should not add .js to short references', function (done) {
+
+            setup();
+
+            streamRevision.on('data', function (file) { });
+            streamRevision.on('end', function () {
+
+                var contents = String(files['/script/app.js'].contents);
+                contents.should.not.containEql('var short = require(' + files['/script/short.js'].revFilename + ');');
+                done();
+
+            });
+
+            gulp.src(['test/fixtures/config1/**']).pipe(streamRevision);
+
+        });
+
+        it('should not resolve arbitrary text with the same name as a file', function (done) {
 
             setup();
 
@@ -832,6 +849,7 @@ describe('gulp-rev-all', function () {
 
                 var contents = String(files['/script/app.js'].contents);
                 contents.should.not.containEql('var ' + files['/script/short.js'].revFilename);
+                contents.should.not.containEql('function (' + files['/script/app.js'].revFilename + ')');
                 done();
 
             });

--- a/test.js
+++ b/test.js
@@ -1125,10 +1125,9 @@ describe('gulp-rev-all', function () {
 
                         var references = Tool.get_reference_representations_relative(fileReference, file);
 
-                        references.length.should.equal(3);
+                        references.length.should.equal(2);
                         references[0].should.equal('script.js');
                         references[1].should.equal('./script.js');
-                        references[2].should.equal('./script');
 
                     });
 

--- a/test.js
+++ b/test.js
@@ -995,9 +995,11 @@ describe('gulp-rev-all', function () {
 
         describe('get_relative_path', function () {
 
-            it('should not truncate a relative path', function () {
+            it('should only truncate paths that overap with the base', function () {
 
                 Tool.get_relative_path('/base/', 'sub/index.html').should.equal('sub/index.html');
+                Tool.get_relative_path('/base/', '/sub/index.html').should.equal('/sub/index.html');
+                Tool.get_relative_path('/base/', '/base/sub/index.html').should.equal('/sub/index.html');
 
             });
 

--- a/test.js
+++ b/test.js
@@ -967,9 +967,9 @@ describe('gulp-rev-all', function () {
 
                 });
 
-                it('should add starting slash', function () {
+                it('should not add starting slash', function () {
 
-                    Tool.join_path('first\\second', 'images.png').should.equal('/first/second/images.png');
+                    Tool.join_path('first\\second', 'images.png').should.equal('first/second/images.png');
 
                 });
 
@@ -983,9 +983,9 @@ describe('gulp-rev-all', function () {
 
                 });
 
-                it('should add starting slash', function () {
+                it('should not add starting slash', function () {
 
-                    Tool.join_path('first/second', 'images.png').should.equal('/first/second/images.png');
+                    Tool.join_path('first/second', 'images.png').should.equal('first/second/images.png');
 
                 });
 

--- a/test.js
+++ b/test.js
@@ -995,6 +995,12 @@ describe('gulp-rev-all', function () {
 
         describe('get_relative_path', function () {
 
+            it('should not truncate a relative path', function () {
+
+                Tool.get_relative_path('/base/', 'sub/index.html').should.equal('sub/index.html');
+
+            });
+
             describe('windows', function () {
 
                 it('should correct slashes', function () {

--- a/tool.js
+++ b/tool.js
@@ -137,8 +137,7 @@ module.exports = (function() {
 
         //  Scenario 1: Current file is anywhere
         //  /view/index.html  (reference: absolute)
-        var r = get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false);
-        representations.push(r);
+        representations.push(get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false));
         
         // Without starting slash, only if it contains a directory
         // view/index.html  (reference: absolute, without slash prefix)

--- a/tool.js
+++ b/tool.js
@@ -141,10 +141,7 @@ module.exports = (function() {
 
         //  Scenario 1: Current file is anywhere
         //  /view/index.html  (reference: absolute)
-        representation = get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false);
-        if(representation){
-            representations.push(representation);
-        }
+        representations.push(get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false));
         
         // Without starting slash, only if it contains a directory
         // view/index.html  (reference: absolute, without slash prefix)

--- a/tool.js
+++ b/tool.js
@@ -45,8 +45,14 @@ module.exports = (function() {
             path = path.substr(base.length);
         }
 
-        if (path[0] === '/' && noStartingSlash) {
-            path = path.substr(1);
+        var modifyStartingSlash = noStartingSlash !== undefined;
+
+        if(modifyStartingSlash) {
+            if (path[0] === '/' && noStartingSlash) {
+                path = path.substr(1);
+            } else if (path[0] !== '/' && !noStartingSlash){
+                path = '/' + path;
+            }
         }
 
         return path;
@@ -95,6 +101,9 @@ module.exports = (function() {
             //  ./index.html   (reference: relative)
             representations.push('.' + get_relative_path(Path.dirname(file.path), fileCurrentReference.revPathOriginal, false));
 
+            //  /index.html
+            representations.push(get_relative_path(Path.dirname(file.path), fileCurrentReference.revPathOriginal, false));
+
         }
 
         //  Scenario 3: Current file is in a different child directory than the reference
@@ -114,20 +123,6 @@ module.exports = (function() {
             var relPath = Path.relative(pathFile, pathCurrentReference);
             relPath = relPath.replace(/\\/g, '/');
             representations.push(relPath + '/' + Path.basename(fileCurrentReference.revPathOriginal));
-        }
-
-        // Only care about trying to match shorthand javascript includes in javascript file context
-        if (file.revPathOriginal.match(/\.js$/ig)) {
-            // Create alternative representations for javascript files for frameworks that omit the .js extension
-            for (var i = 0, length = representations.length; i < length; i++) {
-
-                // Skip non-javascript files, also ensure the folder has at least one directory in it (so we don't end up with super short single words)
-                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)){
-                    continue;
-                }
-
-                representations.push(representations[i].substr(0, representations[i].length - 3));
-            }
         }
 
         return representations;

--- a/tool.js
+++ b/tool.js
@@ -146,20 +146,6 @@ module.exports = (function() {
             representations.push(representation);
         }
 
-        // Only care about trying to match shorthand javascript includes in javascript file context
-        if (file.revPathOriginal.match(/\.js$/ig)) {
-            // Create alternative representations for javascript files for frameworks that omit the .js extension
-            for (var i = 0, length = representations.length; i < length; i++) {
-
-                // Skip non-javascript files, also ensure the folder has at least one directory in it (so we don't end up with super short single words)
-                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)) {
-                    continue;
-                }
-
-                representations.push(representations[i].substr(0, representations[i].length - 3));
-            }
-        }
-
         return representations;
 
     };

--- a/tool.js
+++ b/tool.js
@@ -152,7 +152,9 @@ module.exports = (function() {
             for (var i = 0, length = representations.length; i < length; i++) {
 
                 // Skip non-javascript files, also ensure the folder has at least one directory in it (so we don't end up with super short single words)
-                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)) continue;
+                if (!representations[i].match(/\.js$/ig) || !representations[i].match(/\//ig)) {
+                    continue;
+                }
 
                 representations.push(representations[i].substr(0, representations[i].length - 3));
             }

--- a/tool.js
+++ b/tool.js
@@ -100,10 +100,6 @@ module.exports = (function() {
 
             //  ./index.html   (reference: relative)
             representations.push('.' + get_relative_path(Path.dirname(file.path), fileCurrentReference.revPathOriginal, false));
-
-            //  /index.html
-            representations.push(get_relative_path(Path.dirname(file.path), fileCurrentReference.revPathOriginal, false));
-
         }
 
         //  Scenario 3: Current file is in a different child directory than the reference
@@ -141,7 +137,8 @@ module.exports = (function() {
 
         //  Scenario 1: Current file is anywhere
         //  /view/index.html  (reference: absolute)
-        representations.push(get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false));
+        var r = get_relative_path(fileCurrentReference.base, fileCurrentReference.revPathOriginal, false);
+        representations.push(r);
         
         // Without starting slash, only if it contains a directory
         // view/index.html  (reference: absolute, without slash prefix)

--- a/tool.js
+++ b/tool.js
@@ -4,6 +4,11 @@ var crypto = require('crypto');
 module.exports = (function() {
     'use strict';
 
+    var path_without_ext = function(path) {
+        var ext = Path.extname(path);
+        return path.substr(0, path.length - ext.length);
+    };
+
     var join_path_url = function (prefix, path) {
 
         prefix = prefix.replace(/\/$/, '');
@@ -171,6 +176,7 @@ module.exports = (function() {
         get_relative_path: get_relative_path,
         md5: md5,
         is_binary_file: is_binary_file,
+        path_without_ext: path_without_ext,
         join_path: join_path,
         join_path_url: join_path_url,
         get_reference_representations_relative: get_reference_representations_relative,


### PR DESCRIPTION
I've fixed some of the issues I've been experiencing.

1. The ```join_path``` function prefixed all paths with a slash. This is problematic as it resulted it some relative paths resolving the the file system root and raising an error.

2. The ```get_relative_path``` path function assumed that ```base``` is at the root of ```path```. When truncating ```base.length``` characters off ```path``` an empty string would result if the path was shorter than the base.

3. I've changed the behaviour of the ```noStartingSlash``` parameter in ```get_relative_path``` so that it results in the path having no starting slash. The previous behaviour made no sense to me. Correct me if I misunderstood something.

4. I've also made some style fixes that my linter picked up. Triple equals and brackets around if statements mostly.

I've not managed to get things 100% working for my use case, but this irons out some of the more obvious issues.