### PR TITLE
Pass file being updated to transformPath

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -326,7 +326,7 @@ var Revisioner = (function () {
             }
 
             // Transform path using client supplied transformPath callback, if none try and append with user supplied prefix (defaults to '')
-            pathReferenceReplace = (this.options.transformPath) ? this.options.transformPath.call(this, pathReferenceReplace, reference.path, reference.file) :
+            pathReferenceReplace = (this.options.transformPath) ? this.options.transformPath.call(this, pathReferenceReplace, reference.path, reference.file, file) :
                                    (this.options.prefix && pathReferenceReplace[0] == '/') ? this.Tool.join_path_url(this.options.prefix, pathReferenceReplace) : pathReferenceReplace;
 
             if (this.shouldUpdateReference(reference.file)) {


### PR DESCRIPTION
Sometimes the path needs to be different for different files, but there is no way to tell what file you are operating on without this value.

My specific case is that I want to rewrite some URLs as CDN urls. But which CDN url to use depends on the region that the index.html file is for. My html is built into `html/<region>/<locale>/index.html` and I want to rev the resources listed inside it, but I need to know the region of the file it is operating on to decide which cdn url to use in `transformPath`.

This change passes the file that is currently being modified which lets me get this information from the path.