### PR TITLE
Upper case letters are considered non-filename type characters

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -203,7 +203,7 @@ var Revisioner = (function () {
                 var reference = referenceGroup[referenceIndex];
 
                 // Expect left and right sides of the reference to be a non-filename type character, escape special regex chars
-                var regExp = '([^a-z0-9\\.\\-\\_/])(' + reference.path.replace(/([^0-9a-z])/ig, '\\$1') + ')([^a-z0-9\\.\\-\\_]|$)';
+                var regExp = '([^a-zA-Z0-9\\.\\-\\_/])(' + reference.path.replace(/([^0-9a-z])/ig, '\\$1') + ')([^a-zA-Z0-9\\.\\-\\_]|$)';
                 regExp = new RegExp(regExp, 'g');
 
                 if (contents.match(regExp)) {

--- a/test.js
+++ b/test.js
@@ -869,6 +869,9 @@ describe('gulp-rev-all', function () {
                 // Rebuild include as we should expect it, eg.  require('./short.abcdef');
                 var reference = './' + files['/script/short.js'].revFilename.substr(0, files['/script/short.js'].revFilename.length - 3);
                 contents.should.containEql(reference);
+
+                reference = './' + files['/script/shortDuplicate.js'].revFilename.substr(0, files['/script/shortDuplicate.js'].revFilename.length - 3);
+                contents.should.containEql(reference);
                 done();
 
             });

--- a/test/fixtures/config1/script/app.js
+++ b/test/fixtures/config1/script/app.js
@@ -2,7 +2,7 @@
 
 var layout = require('./layout.js');
 var short = require('./short');
-
+var shortDuplicate = require('./shortDuplicate');
 
 var items = ['short'];
 var short = function() {

--- a/test/fixtures/config1/script/shortDuplicate.js
+++ b/test/fixtures/config1/script/shortDuplicate.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.hello = function() {
+  return 'Hello!'
+};
+


### PR DESCRIPTION
Upper case letters are considered non-filename type characters. This becomes problematic when parts of one filename collides with another filename that has upper case letters. 

Test-case:
```javascript
var short = require('./short');
var shortDuplicate = require('./shortDuplicate');
```

Before patch:
```javascript
var short = require('./short.4b3cfa67');
var shortDuplicate = require('./short.4b3cfa67Duplicate');
```

After patch:
```javascript
var short = require('./short.4b3cfa67');
var shortDuplicate = require('./shortDuplicate.8aed39d3');
```