### PR TITLE
Allow constructor to be called as a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ var Revisioner = require('./revisioner');
 var RevAll = (function () {
 
     var RevAll = function (options) {
+        
+        if (!(this instanceof RevAll)) {
+            return new RevAll(options);
+        }
 
         this.revisioner = new Revisioner(options);
 


### PR DESCRIPTION
Idiomatic use for gulp seems to be to pipe to the output of a function call, which also works more naturally with requires that need a setup.

Current behavior (throwaway variable `require`):
```javascript
var RevAll = require('gulp-rev-all');
var revision = new RevAll({ /*options*/ };
```

Current behavior as one-liner (non-idiomatically invoked `require`):
```javascript
var revision = new (require('gulp-rev-all'))({ /*options*/ });
```

New proposed behavior (idiomatic immediately invoked `require`):
```javascript
var revision = require('gulp-rev-all')({ /*options*/ });
```

What do you think?

