### PR TITLE
Don't attempt to replace references inside blacklisted files

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -345,8 +345,8 @@ var Revisioner = (function () {
      */
     Revisioner.prototype.updateReferences = function (file) {
 
-        // Don't try and update references in binary files
-        if (this.Tool.is_binary_file(file)) {
+        // Don't try and update references in binary files or blacklisted files
+        if (this.Tool.is_binary_file(file) || !this.shouldSearchFile(file)) {
             return;
         }
 


### PR DESCRIPTION
When a file is not searched for references, replacing references should not be attempted. Attempting to replace references inside a blacklisted file sometimes breaks it. PDF's is one such instance.