### PR TITLE
allow query params in the list of non filename chars

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -41,7 +41,7 @@ var Revisioner = (function () {
         this.Tool = Tool;
 
 
-        var nonFileNameChar = '[^a-zA-Z0-9\\.\\-\\_\\/]';
+        var nonFileNameChar = '[^a-zA-Z0-9=\\.\\-\\_\\/\\?]';
         var qoutes = '\'|"';
 
         function referenceToRegexs(reference) {


### PR DESCRIPTION
This allows us to keep the filename but to add query params in the replacer which works great when publishing to S3 and cloudfront as we don't want to pollute S3

associated transform and replacer:

```
gulp.task('rev-all', function () {
    var revAll = new $.revAll({
        dontRenameFile: [
            /^\/favicon.ico$/g,
            /^\/index.html/g,
        ],
        transformFilename: function (file) {
            var ext = path.extname(file.path);
            return path.basename(file.path, ext) + ext;
        },
        replacer: function(fragment, replaceRegExp, newReference, referencedFile) {
            fragment.contents = fragment.contents.replace(
                replaceRegExp,
                '$1' + newReference + '$3?v=' + referencedFile.revHash + '$4'
            );
        }
    });

    return gulp.src('public/**')
        .pipe(revAll.revision())
        .pipe(gulp.dest('dist'));
});
```