### PR TITLE
Add `dontReferenceFile` option, can be used to break circular referen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ Don't search for references in files matching these rules<br/>
 Type: `Array of (Regex and/or String)`<br/>
 Default: `[]`
 
+#### dontReferenceFile
+Don't count files matching these rules as references<br/>
+Type: `Array of (Regex and/or String)`<br/>
+Default: `[]`
+
 In some cases, you may not want to rev your `*.html` files:
 
 ```js

--- a/revisioner.js
+++ b/revisioner.js
@@ -13,6 +13,9 @@ var Revisioner = (function () {
             'dontRenameFile': [],
             'dontUpdateReference': [],
             'dontSearchFile': [],
+
+            'dontReferenceFile': [],
+
             'fileNameVersion': 'rev-version.json',
             'fileNameManifest': 'rev-manifest.json',
             'prefix': '',
@@ -243,6 +246,12 @@ var Revisioner = (function () {
 
             for (var referenceIndex = 0, referenceGroupLength = referenceGroup.length; referenceIndex < referenceGroupLength; referenceIndex++) {
                 var reference = referenceGroup[referenceIndex];
+
+                if(!this.shouldReferenceFile(reference.file)){
+                    this.log('gulp-rev-all:', 'Found', referenceType, 'reference [', Gutil.colors.magenta(reference.path), '] -> [', Gutil.colors.green(reference.file.path), '] in [', Gutil.colors.blue(fileResolveReferencesIn.revPathOriginal), '], but it matches `dontReferenceFile` rules, skipping.');
+                    continue;
+                }
+
                 var regExps = this.options.referenceToRegexs(reference);
 
                 for (var j = 0; j < regExps.length; j++) {
@@ -453,6 +462,24 @@ var Revisioner = (function () {
 
         for (var i = this.options.dontSearchFile.length; i--;) {
             var regex = (this.options.dontSearchFile[i] instanceof RegExp) ? this.options.dontSearchFile[i] : new RegExp(this.options.dontSearchFile[i] + '$', 'ig');
+            if (filename.match(regex)) {
+                return false;
+            }
+        }
+        return true;
+
+    };
+
+    /**
+     * Determines if a particular file should be count as reference.
+     */
+    Revisioner.prototype.shouldReferenceFile = function (file) {
+
+        var filename = this.Tool.get_relative_path(file.base, file.revPathOriginal);
+
+        for (var i = this.options.dontReferenceFile.length; i--;) {
+            var item = this.options.dontReferenceFile[i];
+            var regex = (item instanceof RegExp) ? item : new RegExp(item + '$', 'ig');
             if (filename.match(regex)) {
                 return false;
             }


### PR DESCRIPTION
Add `dontReferenceFile` option, can be used to break circular references.

Consider this case:
- `index.html` reference `index.js`, `index.js` reference `index.html`,
- When `index.html` changes, the revision hash of `index.js` changes as well, this is not necessary.
- In this case, `dontReferenceFile:['.html']` can be used to ignore `index.html` file in the revision hashing process of `index.js`.