### PR TITLE
Update hash of a file based on prefix & presence of absolute references.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var jshint = require('gulp-jshint');
 var mocha = require('gulp-mocha');
 
 gulp.task('lint', function() {
-	return gulp.src('test/test.js')
+	return gulp.src('test.js')
 		.pipe(jshint())
 		.pipe(jshint.reporter('default'))
 		.pipe(mocha());

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "devDependencies": {
         "gulp": "~3.5.5",
         "gulp-jshint": "~1.5.1",
-        "gulp-mocha": "~0.4.1",
+        "gulp-mocha": "~2.2.0",
         "mocha": "~2.2.1",
         "should": "*"
     },

--- a/revisioner.js
+++ b/revisioner.js
@@ -199,18 +199,17 @@ var Revisioner = (function () {
         var contents = String(fileResolveReferencesIn.revContentsOriginal);
         fileResolveReferencesIn.revReferencePaths = {};
         fileResolveReferencesIn.revReferenceFiles = {};
+        var referenceGroupRelative = [];
+        var referenceGroupAbsolute = [];
+        fileResolveReferencesIn.referenceGroupsContainer = {
+            'relative': referenceGroupRelative,
+            'absolute': referenceGroupAbsolute
+        };
 
         // Don't try and resolve references in binary files or files that have been blacklisted
         if (this.Tool.is_binary_file(fileResolveReferencesIn) || !this.shouldSearchFile(fileResolveReferencesIn)) {
             return;
         }
-
-        var referenceGroupRelative = [];
-        var referenceGroupAbsolute = [];
-        var referenceGroupsContainer = {
-            'relative': referenceGroupRelative,
-            'absolute': referenceGroupAbsolute
-        };
 
         // For the current file (fileResolveReferencesIn), look for references to any other file in the project
         for (var path in this.files) {
@@ -238,8 +237,8 @@ var Revisioner = (function () {
         }
 
         // Priority relative references higher than absolute
-        for (var referenceType in referenceGroupsContainer) {
-            var referenceGroup = referenceGroupsContainer[referenceType];
+        for (var referenceType in fileResolveReferencesIn.referenceGroupsContainer) {
+            var referenceGroup = fileResolveReferencesIn.referenceGroupsContainer[referenceType];
 
             for (var referenceIndex = 0, referenceGroupLength = referenceGroup.length; referenceIndex < referenceGroupLength; referenceIndex++) {
                 var reference = referenceGroup[referenceIndex];
@@ -292,6 +291,12 @@ var Revisioner = (function () {
                     hash += this.calculateHash(file.revReferenceFiles[key], stack);
                 }
 
+            }
+
+            // This file's hash should change if any of its references will be prefixed.
+            if (this.options.prefix &&
+                    Object.keys(file.referenceGroupsContainer.absolute).length) {
+              hash += this.options.prefix;
             }
 
             // Consolidate many hashes into one
@@ -361,7 +366,7 @@ var Revisioner = (function () {
             var referencePath = reference.path.substr(0, reference.path.length - (reference.file.revFilenameOriginal.length + reference.file.revFilenameExtOriginal.length));
             var pathReferenceReplace = referencePath + reference.file.revFilename;
 
-            
+
             if (this.options.transformPath) {
                 // Transform path using client supplied transformPath callback,
                 pathReferenceReplace = this.options.transformPath.call(this, pathReferenceReplace, reference.path, reference.file, file);

--- a/test.js
+++ b/test.js
@@ -66,6 +66,29 @@ describe('gulp-rev-all', function () {
 
         });
 
+        it('should change if the prefix changed and it has absolute references', function (done) {
+
+            setup();
+
+            streamRevision.on('data', function (file) { });
+            streamRevision.on('end', function () {
+
+                var pathBaseline = files['/index.html'].path;
+
+                // Apply a prefix to absolute references.
+                revisioner.options.prefix = 'http://example.com/';
+
+                // Re-run the revisioner to re-calculate the filename hash
+                revisioner.run();
+                files['/index.html'].path.should.not.equal(pathBaseline);
+
+                done();
+            });
+
+            gulp.src(['test/fixtures/config1/**']).pipe(streamRevision);
+
+        });
+
         /**
          * Should resolve hash change, both ways
          * Context: https://github.com/smysnk/gulp-rev-all/pull/44
@@ -106,7 +129,7 @@ describe('gulp-rev-all', function () {
                 files['/view/gps.html'].path.should.equal(pathGpsBaseline);
                 files['/view/about.html'].path.should.equal(pathAboutBaseline);
                 files['/view/main.html'].path.should.equal(pathMainBaseline);
-                
+
                 // Try the other reference
                 files['/view/main.html'].revHashOriginal = 'changed';
                 revisioner.run();


### PR DESCRIPTION
Motivation: I was trying to update my prefix from e.g. `http://1234.cloudfront.net/` to a friendlier `cdn.example.com` domain. The filenames didn't change since `revisionFilename` happens before `updateReferences`, so the modified references were not factored into the original hashing. Even though I uploaded the modified files to my S3 bucket backing the cloudfront distro, the new versions were not served to my browser as the original versions were set to never expire and cached by cloudfront.