### PR TITLE
Fix: relative references starting with `./` were not replaced on Windows

### DIFF
--- a/test.js
+++ b/test.js
@@ -1211,30 +1211,32 @@ describe('gulp-rev-all', function () {
 
                     });
 
-                    it('windows path', function () {
+                    if (/^win/.test(process.platform)) {
+                        it('windows path', function () {
 
-                        var base = 'c:\\first\\second';
+                            var base = 'c:\\first\\second';
 
-                        var file = new Gutil.File({
-                            path: 'c:\\first\\second\\third\\index.html',
-                            base: base
+                            var file = new Gutil.File({
+                                path: 'c:\\first\\second\\third\\index.html',
+                                base: base
+                            });
+
+                            var fileReference = new Gutil.File({
+                                path: 'c:\\first\\second\\third\\fourth\\other.html',
+                                base: base
+                            });
+
+                            file.revPathOriginal = file.path;
+                            fileReference.revPathOriginal = fileReference.path;
+
+                            var references = Tool.get_reference_representations_relative(fileReference, file);
+
+                            references.length.should.equal(2);
+                            references[0].should.equal('fourth/other.html');
+                            references[1].should.equal('./fourth/other.html');
+
                         });
-
-                        var fileReference = new Gutil.File({
-                            path: 'c:\\first\\second\\third\\fourth\\other.html',
-                            base: base
-                        });
-
-                        file.revPathOriginal = file.path;
-                        fileReference.revPathOriginal = fileReference.path;
-
-                        var references = Tool.get_reference_representations_relative(fileReference, file);
-
-                        references.length.should.equal(2);
-                        references[0].should.equal('fourth/other.html');
-                        references[1].should.equal('./fourth/other.html');
-
-                    });
+                    }
 
                 });
 

--- a/test.js
+++ b/test.js
@@ -1211,6 +1211,31 @@ describe('gulp-rev-all', function () {
 
                     });
 
+                    it('windows path', function () {
+
+                        var base = 'c:\\first\\second';
+
+                        var file = new Gutil.File({
+                            path: 'c:\\first\\second\\third\\index.html',
+                            base: base
+                        });
+
+                        var fileReference = new Gutil.File({
+                            path: 'c:\\first\\second\\third\\fourth\\other.html',
+                            base: base
+                        });
+
+                        file.revPathOriginal = file.path;
+                        fileReference.revPathOriginal = fileReference.path;
+
+                        var references = Tool.get_reference_representations_relative(fileReference, file);
+
+                        references.length.should.equal(2);
+                        references[0].should.equal('fourth/other.html');
+                        references[1].should.equal('./fourth/other.html');
+
+                    });
+
                 });
 
                 describe('should resolve references that have 1 traversals', function () {

--- a/tool.js
+++ b/tool.js
@@ -10,7 +10,7 @@ module.exports = (function() {
     };
     
     var dirname_with_sep = function(path) {
-        return Path.dirname(path) + '/';
+        return Path.dirname(path).replace(/\\/g, '/') + '/';
     }
 
     var join_path_url = function (prefix, path) {


### PR DESCRIPTION
having a reference such as `./subdir/otherfile.txt` was not replaced with the hashed filename on Windows.

This issue was caused by determining the relative paths between `c:\somedir\somefile.txt` and `c:\somedir\subdir\otherfile.txt`. In the implementation this caused directories `c:\somedir/` to be compared to `c:\somedir\subdir/` to determine if the second one is a subdir of the first one, which fails because of the usage of both / and \
This issues only reproduces on windows because of the \ usage. Relative references like `subdir/otherfile.txt` were replaced correctly, it's just with the `./` prefix that things went wrong.