### PR TITLE
includeFilesInManifest option added, see README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Set the filename of the file created by revAll.manifestFile()<br/>
 Type: `String`<br/>
 Default: `rev-manifest.json`
 
+#### includeFilesInManifest
+Add only specific file types to the manifest file<br/>
+Type: `Array of strings`<br/>
+Default: `['.css', '.js']`
+
 #### dontGlobal
 
 Don't rename, search or update refrences in files matching these rules<br/>

--- a/revisioner.js
+++ b/revisioner.js
@@ -19,7 +19,8 @@ var Revisioner = (function () {
             'referenceToRegexs': referenceToRegexs,
             'annotator': annotator,
             'replacer': replacer,
-            'debug': false
+            'debug': false,
+            'includeFilesInManifest': ['.css', '.js']
         };
 
         this.options = Merge(defaults, options);
@@ -339,7 +340,10 @@ var Revisioner = (function () {
         // Maintain the manifset file
         var pathOriginal = this.Tool.get_relative_path(this.pathBase, file.revPathOriginal, true);
         var pathRevisioned = this.Tool.get_relative_path(file.base, file.path, true);
-        this.manifest[pathOriginal] = pathRevisioned;
+        // Add only specific file types to the manifest file
+        if (this.options.includeFilesInManifest.indexOf(ext) !== -1) {
+            this.manifest[pathOriginal] = pathRevisioned;
+        }
 
         file.revPath = pathRevisioned;
 


### PR DESCRIPTION
Hi Joshua, hi all,
we added an option to exclude files from being added to the manifest file. That allows us to keep the manifest file tidy and short and limit it to the files we need to process. We would be glad if you would consider it handy as well and take it over to the master branch.

Greetings from Berlin
Tobi