### PR TITLE
Fixes extensionless typescript file references not being replaced.

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -51,9 +51,10 @@ var Revisioner = (function () {
 
       var regExp, regExps = [];
       var isJSReference = reference.path.match(/\.js$/);
+      var isTSReference = reference.path.match(/\.ts$/);
 
-      // Extensionless javascript file references has to to be qouted
-      if (isJSReference) {
+      // Extensionless javascript and typescript file references have to be quoted
+      if (isJSReference || isTSReference) {
         regExp = '('+ qoutes +')(' + escapedRefPathBase + ')()('+ qoutes + '|$)';
         regExps.push(new RegExp(regExp, 'g'));
       }


### PR DESCRIPTION
When typescript files are referenced without extensions, the current revisioner.js does not pick those references up for replacing. Currently, this only works for extensionless javascript files. This pull request fixes this and adds the same logic for typescript files.