### PR TITLE
Don't stringify the contents of files before passing them to md5 hasher.

### DIFF
--- a/revisioner.js
+++ b/revisioner.js
@@ -154,7 +154,7 @@ var Revisioner = (function () {
     file.revPathOriginal = file.revOrigPath = file.path;
     file.revFilenameExtOriginal = Path.extname(file.path);
     file.revFilenameOriginal = Path.basename(file.path, file.revFilenameExtOriginal);
-    file.revHashOriginal = this.Tool.md5(String(file.contents));
+    file.revHashOriginal = this.Tool.md5(file.contents);
     file.revContentsOriginal = file.contents;
 
     this.filesTemp.push(file);

--- a/tool.js
+++ b/tool.js
@@ -62,10 +62,8 @@ module.exports = (function() {
 
   };
 
-  var md5 = function (str) {
-
-    return crypto.createHash('md5').update(str, 'utf8').digest('hex');
-
+  var md5 = function (buf) {
+    return crypto.createHash('md5').update(buf).digest('hex');
   };
 
   var is_binary_file = function (file) {


### PR DESCRIPTION
As demonstrated [here](https://github.com/wbprice/image-hashing-test/blob/master/index.js), passing a stringified image buffer to the hashing function will yield a different result than if we were to pass an image buffer:

```js
// revisioner.js line 157
    file.revHashOriginal = this.Tool.md5(String(file.contents));
```

```js
// tool.js lines 65-69
var md5 = function (str) {

    return crypto.createHash('md5').update(str, 'utf8').digest('hex');

};
```

The above causes images to be hashed inaccurately.

`Hash#update` accepts a buffer or string as the first argument, when `md5` is used again to hash the consolidated hash, it still works.

```js
// revisioner.js lines 310-311
// Consolidate many hashes into one
hash = this.Tool.md5(hash);
```

Fixes #129 