### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var Through = require('through2');
 var Revisioner = require('./revisioner');
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-rev-all';
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Static asset revisioning by appending content hash to filenames: unicorn.css => unicorn.098f6bcd.css, also re-writes references in each file to new reved name.",
   "main": "index.js",
   "dependencies": {
-    "chalk": "~0.4.0",
-    "gulp-util": "~2.2.14",
+    "chalk": "^1.1.3",
+    "fancy-log": "^1.3.2",
     "merge": "^1.2.0",
-    "through2": "~0.4.0"
+    "plugin-error": "^0.1.2",
+    "through2": "~0.4.0",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "event-stream": "^3.3.4",

--- a/revisioner.js
+++ b/revisioner.js
@@ -1,4 +1,6 @@
-var Gutil = require('gulp-util');
+var Vinyl = require('vinyl');
+var fancyLog = require('fancy-log');
+var chalk = require('chalk');
 var Merge = require('merge');
 var Path = require('path');
 var Tool = require('./tool');
@@ -36,7 +38,7 @@ var Revisioner = (function () {
     this.manifest = {};
 
     // Enable / Disable logger based on supplied options
-    this.log = (this.options.debug) ? Gutil.log : function () {};
+    this.log = (this.options.debug) ? fancyLog : function () {};
 
     // Make tools available client side callbacks supplied in options
     this.Tool = Tool;
@@ -82,7 +84,7 @@ var Revisioner = (function () {
       timestamp: new Date()
     };
 
-    var file = new Gutil.File({
+    var file = new Vinyl({
       cwd: this.pathCwd,
       base: this.pathBase,
       path: Path.join(this.pathBase, this.options.fileNameVersion),
@@ -97,7 +99,7 @@ var Revisioner = (function () {
 
   Revisioner.prototype.manifestFile = function () {
 
-    var file = new Gutil.File({
+    var file = new Vinyl({
       cwd: this.pathCwd,
       base: this.pathBase,
       path: Path.join(this.pathBase, this.options.fileNameManifest),
@@ -263,12 +265,12 @@ var Revisioner = (function () {
                 'file': reference.file,
                 'path': reference.path
               };
-              this.log('gulp-rev-all:', 'Found', referenceType, 'reference [', Gutil.colors.magenta(reference.path), '] -> [', Gutil.colors.green(reference.file.path), '] in [', Gutil.colors.blue(fileResolveReferencesIn.revPathOriginal), ']');
+              this.log('gulp-rev-all:', 'Found', referenceType, 'reference [', chalk.magenta(reference.path), '] -> [', chalk.green(reference.file.path), '] in [', chalk.blue(fileResolveReferencesIn.revPathOriginal), ']');
             } else if (fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal === reference.file.revPathOriginal) {
               // Append the other regexes to account for inconsitent use
               fileResolveReferencesIn.revReferencePaths[reference.path].regExps.push(regExps[j]);
             } else {
-              this.log('gulp-rev-all:', 'Possible ambiguous reference detected [', Gutil.colors.red(fileResolveReferencesIn.revReferencePaths[reference.path].path), ' (', fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal, ')] <-> [', Gutil.colors.red(reference.path), '(', Gutil.colors.red(reference.file.revPathOriginal), ')]');
+              this.log('gulp-rev-all:', 'Possible ambiguous reference detected [', chalk.red(fileResolveReferencesIn.revReferencePaths[reference.path].path), ' (', fileResolveReferencesIn.revReferencePaths[reference.path].file.revPathOriginal, ')] <-> [', chalk.red(reference.path), '(', chalk.red(reference.file.revPathOriginal), ')]');
             }
           }
         }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ var Revisioner = require('./revisioner');
 var Tool = require('./tool');
 var Path = require('path');
 var gulp = require('gulp');
-var Gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var es = require('event-stream');
 
 require('should');
@@ -1166,12 +1166,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/script.js',
               base: base
             });
@@ -1191,12 +1191,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/other.js',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/script.js',
               base: base
             });
@@ -1220,12 +1220,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/other.html',
               base: base
             });
@@ -1245,12 +1245,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/fourth/other.html',
               base: base
             });
@@ -1271,12 +1271,12 @@ describe('gulp-rev-all', function () {
 
               var base = 'c:\\first\\second';
 
-              var file = new Gutil.File({
+              var file = new Vinyl({
                 path: 'c:\\first\\second\\third\\index.html',
                 base: base
               });
 
-              var fileReference = new Gutil.File({
+              var fileReference = new Vinyl({
                 path: 'c:\\first\\second\\third\\fourth\\other.html',
                 base: base
               });
@@ -1301,12 +1301,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/index.html',
               base: base
             });
@@ -1325,12 +1325,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });
@@ -1349,12 +1349,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/thirder/index.html',
               base: base
             });
@@ -1373,12 +1373,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/advanced/index.html',
               base: base
             });
@@ -1401,12 +1401,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/index.html',
               base: base
             });
@@ -1425,12 +1425,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });
@@ -1449,12 +1449,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/fifth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });
@@ -1481,12 +1481,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/script.js',
               base: base
             });
@@ -1506,12 +1506,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/other.js',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/script.js',
               base: base
             });
@@ -1535,12 +1535,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/other.html',
               base: base
             });
@@ -1560,12 +1560,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/fourth/other.html',
               base: base
             });
@@ -1589,12 +1589,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/index.html',
               base: base
             });
@@ -1614,12 +1614,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });
@@ -1639,12 +1639,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/thirder/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
@@ -1664,12 +1664,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/advanced/index.html',
               base: base
             });
@@ -1693,12 +1693,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/index.html',
               base: base
             });
@@ -1718,12 +1718,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });
@@ -1743,12 +1743,12 @@ describe('gulp-rev-all', function () {
 
             var base = '/first/second';
 
-            var file = new Gutil.File({
+            var file = new Vinyl({
               path: '/first/second/third/fourth/fifth/index.html',
               base: base
             });
 
-            var fileReference = new Gutil.File({
+            var fileReference = new Vinyl({
               path: '/first/second/other/index.html',
               base: base
             });


### PR DESCRIPTION
Closes smysnk/gulp-rev-all#182