### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,19 @@
   "description": "Static asset revisioning by appending content hash to filenames: unicorn.css => unicorn.098f6bcd.css, also re-writes references in each file to new reved name.",
   "main": "index.js",
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.4.1",
     "fancy-log": "^1.3.2",
     "merge": "^1.2.0",
-    "plugin-error": "^0.1.2",
-    "through2": "~0.4.0",
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "event-stream": "^3.3.4",
     "gulp": "~3.9.1",
-    "gulp-jshint": "~1.5.1",
-    "gulp-mocha": "~2.2.0",
-    "mocha": "~2.2.1",
+    "gulp-jshint": "^2.1.0",
+    "gulp-mocha": "^6.0.0",
+    "mocha": "^5.2.0",
     "should": "*"
   },
   "scripts": {


### PR DESCRIPTION
```
chalk               1.1.3  ❯  2.4.1  https://github.com/chalk/chalk#readme
plugin-error        0.1.2  ❯  1.0.1  https://github.com/gulpjs/plugin-error#readme
through2            0.4.2  ❯  2.0.3  https://github.com/rvagg/through2#readme
gulp-jshint devDep  1.5.6  ❯  2.1.0  http://github.com/spalger/gulp-jshint
gulp-mocha devDep   2.2.0  ❯  6.0.0  https://github.com/sindresorhus/gulp-mocha#readme
mocha devDep        2.2.5  ❯  5.2.0  https://mochajs.org
  ```