### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+on: push
+name: Run tests
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [8, 10, 11, 12, 13]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - 8
-  - 10
-  - 11
-  - 12
-  - 13

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-rev-all [![NPM version](https://img.shields.io/npm/v/gulp-rev-all.svg)](https://www.npmjs.com/package/gulp-rev-all) [![Build Status](https://img.shields.io/travis/smysnk/gulp-rev-all.svg)](https://travis-ci.org/smysnk/gulp-rev-all) [![Dependency Status](https://img.shields.io/david/smysnk/gulp-rev-all.svg)](https://david-dm.org/smysnk/gulp-rev-all)
+# gulp-rev-all [![NPM version](https://img.shields.io/npm/v/gulp-rev-all.svg)](https://www.npmjs.com/package/gulp-rev-all) [![Run tests](https://github.com/nfroidure/svg-pathdata/actions/workflows/test.yml/badge.svg)](https://github.com/nfroidure/svg-pathdata/actions/workflows/test.yml) [![Dependency Status](https://img.shields.io/david/smysnk/gulp-rev-all.svg)](https://david-dm.org/smysnk/gulp-rev-all)
 
 > Static asset revisioning with dependency considerations, appends content hash to each filename (eg. unicorn.css => unicorn.098f6bcd.css), re-writes references.
 


### PR DESCRIPTION
Moving to GitHub Actions because it's overall better than Travis (unlimited for OSS, more convenient for those who wants to forks and create PR, ...)