### PR TITLE
baseHref

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,23 @@ gulp.task("default", function () {
 });
 ```
 
+#### baseHref
+
+Matches absolute references that are already served under a base path. Useful when your app is mounted under a subdirectory such as `/www` and files contain references like `/www/script/app.js`.<br/>
+Type: `string`<br/>
+Default: `""`<br/>
+
+```js
+gulp.task("default", function () {
+  gulp
+    .src("dist/**")
+    .pipe(RevAll.revision({ baseHref: "/www" }))
+    .pipe(gulp.dest("cdn"));
+});
+```
+
+For example, with `baseHref: "/www"`, a reference like `/www/script/app.js` will be rewritten to `/www/script/app.<hash>.js`.
+
 #### transformPath
 
 Specify a function to transform the reference path. Useful in instances where the local file structure does not reflect what the remote file structure will be.<br/>

--- a/revisioner.js
+++ b/revisioner.js
@@ -23,6 +23,7 @@ var Revisioner = function (options) {
     fileNameVersion: "rev-version.json",
     fileNameManifest: "rev-manifest.json",
     prefix: "",
+    baseHref: "",
     referenceToRegexs: referenceToRegexs,
     annotator: annotator,
     replacer: replacer,
@@ -261,8 +262,8 @@ Revisioner.prototype.resolveReferences = function (fileResolveReferencesIn) {
     for (i = 0, length = references.length; i < length; i++) {
       referenceGroupAbsolute.push({
         file: this.files[path],
-        path: references[i],
-      });
+        path: join_path(this.options.baseHref, references[i]),
+      })
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -743,6 +743,21 @@ describe("gulp-rev-all", function () {
 
       gulp.src(["test/fixtures/config1/**"]).pipe(streamRevision);
     });
+
+    it("should replace with baseHref", function (done) {
+      setup({
+        baseHref: '/www',
+      })
+      streamRevision.on("data", function () { });
+      streamRevision.on("end", function () {
+        var count = String(files['/index.html'].contents).match(
+          /\/www\/script\/lodash\.[a-z0-9]{8}\.js/g,
+        )
+        should(count).not.be.null()
+        done();
+      });
+      gulp.src(["test/fixtures/config1/**"]).pipe(streamRevision);
+    })
   });
 
   describe("nested html", function () {

--- a/test/fixtures/config1/index.html
+++ b/test/fixtures/config1/index.html
@@ -28,5 +28,8 @@
 
     <a href="/nested/index.html">Nested Site</a>
     <a href="/index.html">Home</a>
+
+    <!-- baseUrl -->
+    <script src="/www/script/lodash.js"></script>
   </body>
 </html>


### PR DESCRIPTION
When a site is not deployed in the root directory and its resource references are written relative to the root directory, hash substitution does not work, for example:
Site address: www.xxx.com/a/b/c/
resource address: /a/b/c/js/xxx.js

You can add a configuration to solve this problem:
`
    {
        baseHref: '/www',
    }
`